### PR TITLE
Build site using dev shinylive

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -30,11 +30,14 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-          extra-repositories: https://jonthegeek.r-universe.dev/
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
+      - name: Install dev shinylive
+        shell: Rscript {0}
+        run: |
+          pak::pak("posit-dev/r-shinylive")
       # Change the build directory to `_site`
       - name: Build site
         shell: Rscript {0}


### PR DESCRIPTION
This is a temporary fix until shinylive is updated to >= v0.3.1 on CRAN. We need the webr version of shinylive and the builder to match one another.